### PR TITLE
fix inconsistent frame size bug

### DIFF
--- a/src/tidytunes/models/speaker_encoder.py
+++ b/src/tidytunes/models/speaker_encoder.py
@@ -67,14 +67,15 @@ class SpeakerEncoder(torch.nn.Module):
         return embeddings
 
     def split_to_chunks(self, x: torch.Tensor):
-
         num_samples = min(self.num_input_frames * self.hop_length, x.shape[1])
-        num_outputs = torch.ceil(torch.tensor(x.shape[1] / num_samples)).int()
+        num_full_chunks = (
+            x.shape[1] // num_samples
+        )  # Calculate the number of full chunks
 
         frames_flat = []
-        for offset in torch.linspace(0, x.shape[1] - num_samples, num_outputs):
-            s = int(offset)
-            e = int(offset + num_samples)
+        for i in range(num_full_chunks):
+            s = i * num_samples
+            e = s + num_samples
             frames_flat.append(x[:, s:e])
 
         frames_flat = torch.cat(frames_flat, dim=0)


### PR DESCRIPTION
The following exception can appear at this line of code: `frames_flat = torch.cat(frames_flat, dim=0)`:

```
Sizes of tensors must match except in dimension 0. Expected size 10240 but got size 10241 for tensor number 13 in the list.
```

This can happen because the `torch.linspace` can output inconsistent hop lengths if the total length is not aligned with `num_samples`, e.g. `[10240, 10240, ..., 10241, 10240]`. 

The fix is just a suggestion, feel free to use something smarter.  