### PR TITLE
catch cufft oom

### DIFF
--- a/src/tidytunes/bin/process_audio.py
+++ b/src/tidytunes/bin/process_audio.py
@@ -17,7 +17,7 @@ from tidytunes.pipeline_components import (
 )
 from tidytunes.pipeline_components.dnsmos import load_dnsmos_model
 from tidytunes.utils import Audio, partition, setup_logger, trim_audios
-from tidytunes.utils.memory import garbage_collection_cuda, is_cuda_out_of_memory
+from tidytunes.utils.memory import garbage_collection_cuda, is_oom_error
 
 PIPELINE_FUNCTIONS = {
     "voice_separation": find_segments_without_music,
@@ -49,7 +49,7 @@ def process_audio(audios, device, pipeline_components):
             else:
                 audio_segments = trim_audios(audio_segments, values)
         except RuntimeError as e:
-            if not is_cuda_out_of_memory(e):
+            if not is_oom_error(e):
                 raise
             garbage_collection_cuda()
             audio_segments = []

--- a/src/tidytunes/utils/memory.py
+++ b/src/tidytunes/utils/memory.py
@@ -9,6 +9,7 @@ def is_oom_error(exception: BaseException) -> bool:
         or is_cudnn_snafu(exception)
         or is_out_of_cpu_memory(exception)
         or is_onnx_out_of_memory(exception)
+        or is_cufft_out_of_memory(exception)
     )
 
 
@@ -37,6 +38,14 @@ def is_cufft_snafu(exception: BaseException) -> bool:
         isinstance(exception, RuntimeError)
         and len(exception.args) >= 1
         and "cuFFT error: CUFFT_INTERNAL_ERROR" in exception.args[0]
+    )
+
+
+def is_cufft_out_of_memory(exception: BaseException) -> bool:
+    return (
+        isinstance(exception, RuntimeError)
+        and len(exception.args) >= 1
+        and "cuFFT error: CUFFT_ALLOC_FAILED" in exception.args[0]
     )
 
 


### PR DESCRIPTION
CUFFT can also throw OOM exception, which is not handled, so it crashes the entire pipeline.

``` 
File "/fsx_home/homes/srdecny/tidy-tunes/src/tidytunes/bin/process_audio.py", line 133, in process_audios
    audio_segments, throughput_stats = process_audio(
                                       ^^^^^^^^^^^^^^
  File "/fsx_home/homes/srdecny/tidy-tunes/src/tidytunes/bin/process_audio.py", line 44, in process_audio
    values = func(audio_segments, device=device, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/fsx_home/homes/srdecny/tidy-tunes/src/tidytunes/pipeline_components/rolloff.py", line 33, in get_rolloff_frequency
    rolloff = extractor(w)
              ^^^^^^^^^^^^
  File "/fsx_home/homes/srdecny/tidy-tunes/env/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/fsx_home/homes/srdecny/tidy-tunes/env/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: The following operation failed in the TorchScript interpreter.
Traceback of TorchScript (most recent call last):
/fsx_home/homes/srdecny/tidy-tunes/src/tidytunes/models/rolloff.py(34): forward
/fsx_home/homes/srdecny/tidy-tunes/env/lib/python3.11/site-packages/torch/nn/modules/module.py(1741): _slow_forward
/fsx_home/homes/srdecny/tidy-tunes/env/lib/python3.11/site-packages/torch/nn/modules/module.py(1762): _call_impl
/fsx_home/homes/srdecny/tidy-tunes/env/lib/python3.11/site-packages/torch/nn/modules/module.py(1751): _wrapped_call_impl
/fsx_home/homes/srdecny/tidy-tunes/env/lib/python3.11/site-packages/torch/jit/_trace.py(1279): trace_module
/fsx_home/homes/srdecny/tidy-tunes/env/lib/python3.11/site-packages/torch/jit/_trace.py(696): _trace_impl
/fsx_home/homes/srdecny/tidy-tunes/env/lib/python3.11/site-packages/torch/jit/_trace.py(1002): trace
/fsx_home/homes/srdecny/tidy-tunes/src/tidytunes/utils/trace.py(97): to_jit_trace
/fsx_home/homes/srdecny/tidy-tunes/src/tidytunes/utils/trace.py(46): to_jit_trace
/fsx_home/homes/srdecny/tidy-tunes/src/tidytunes/pipeline_components/rolloff.py(64): get_rolloff_extractor
/fsx_home/homes/srdecny/tidy-tunes/src/tidytunes/pipeline_components/rolloff.py(27): get_rolloff_frequency
/fsx_home/homes/srdecny/tidy-tunes/src/tidytunes/bin/process_audio.py(44): process_audio
/fsx_home/homes/srdecny/tidy-tunes/src/tidytunes/bin/process_audio.py(133): process_audios
/fsx_home/homes/srdecny/tidy-tunes/env/lib/python3.11/site-packages/click/core.py(788): invoke
/fsx_home/homes/srdecny/tidy-tunes/env/lib/python3.11/site-packages/click/core.py(1443): invoke
/fsx_home/homes/srdecny/tidy-tunes/env/lib/python3.11/site-packages/click/core.py(1697): invoke
/fsx_home/homes/srdecny/tidy-tunes/env/lib/python3.11/site-packages/click/core.py(1082): main
/fsx_home/homes/srdecny/tidy-tunes/env/lib/python3.11/site-packages/click/core.py(1161): __call__
/fsx_home/homes/srdecny/tidy-tunes/env/bin/tidytunes(8): <module>
RuntimeError: cuFFT error: CUFFT_ALLOC_FAILED
```