### PR TITLE
catch torchaudio crash

### DIFF
--- a/src/tidytunes/bin/process_audio.py
+++ b/src/tidytunes/bin/process_audio.py
@@ -129,7 +129,11 @@ def process_audios(audio_paths, config, out, device, overwrite):
 
     with open(out_processed, "a+") as f:
         for pth in paths:
-            audio = Audio.from_file(pth)
+            try:
+                audio = Audio.from_file(pth)
+            except Exception as e:
+                click.secho(f"Failed to load audio {pth}: {e}", fg="red", bold=True)
+                continue
             audio_segments, throughput_stats = process_audio(
                 [audio], device, pipeline_components
             )


### PR DESCRIPTION
When loading a corrupted audio, the pipeline crashes because of uncatched exception.
```
  File "/fsx_home/homes/srdecny/tidy-tunes/env/bin/tidytunes", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/fsx_home/homes/srdecny/tidy-tunes/env/lib/python3.11/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/fsx_home/homes/srdecny/tidy-tunes/env/lib/python3.11/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/fsx_home/homes/srdecny/tidy-tunes/env/lib/python3.11/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/fsx_home/homes/srdecny/tidy-tunes/env/lib/python3.11/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/fsx_home/homes/srdecny/tidy-tunes/env/lib/python3.11/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/fsx_home/homes/srdecny/tidy-tunes/src/tidytunes/bin/process_audio.py", line 132, in process_audios
    audio = Audio.from_file(pth)
            ^^^^^^^^^^^^^^^^^^^^
  File "/fsx_home/homes/srdecny/tidy-tunes/src/tidytunes/utils/audio.py", line 76, in from_file
    audio, sr = torchaudio.load(str(path))
                ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/fsx_home/homes/srdecny/tidy-tunes/env/lib/python3.11/site-packages/torchaudio/_backend/utils.py", line 205, in load
    return backend.load(uri, frame_offset, num_frames, normalize, channels_first, format, buffer_size)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/fsx_home/homes/srdecny/tidy-tunes/env/lib/python3.11/site-packages/torchaudio/_backend/ffmpeg.py", line 297, in load
    return load_audio(uri, frame_offset, num_frames, normalize, channels_first, format)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/fsx_home/homes/srdecny/tidy-tunes/env/lib/python3.11/site-packages/torchaudio/_backend/ffmpeg.py", line 89, in load_audio
    sample_rate = int(s.get_src_stream_info(s.default_audio_stream).sample_rate)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/fsx_home/homes/srdecny/tidy-tunes/env/lib/python3.11/site-packages/torio/io/_streaming_media_decoder.py", line 587, in get_src_stream_info
    return _parse_si(self._be.get_src_stream_info(i))
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: get_src_stream_info(): incompatible function arguments. The following argument types are supported:
    1. (self: torio.lib._torio_ffmpeg4.StreamingMediaDecoder, arg0: int) -> torio.lib._torio_ffmpeg4.SourceStreamInfo

Invoked with: <torio.lib._torio_ffmpeg4.StreamingMediaDecoder object at 0x7a5405dcc0b0>, None
```

Outut of `ffprobe` on such corrupted audios:
```
[flac @ 0x60811fbf04c0] Format flac detected only with low score of 1, misdetection possible!
[flac @ 0x60811fbf04c0] Could not find codec parameters for stream 0 (Audio: flac, 0 channels): unspecified sample format
Consider increasing the value for the 'analyzeduration' (0) and 'probesize' (5000000) options
Input #0, flac, from '/cache/youtube_batch5/@idacpodcast/Fo/FoFHgkm0ia0/FoFHgkm0ia0.flac':
  Duration: N/A, bitrate: N/A
  Stream #0:0: Audio: flac, 0 channels
 ```