### PR TITLE
Dnsmos fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tidytunes"
-version = "1.0.1"
+version = "1.0.2"
 description = "An easy-to-use pipeline for mining high-quality audio data for speech generation models."
 readme = "README.md"
 authors = [

--- a/src/tidytunes/models/dnsmos.py
+++ b/src/tidytunes/models/dnsmos.py
@@ -157,7 +157,11 @@ class DNSMOSPredictor(torch.nn.Module):
 
             shape = audio_seg.shape
             audio_seg = audio_seg.reshape((-1, shape[-1])).contiguous()
-            mel_seg = self.extract_features(audio_seg[..., :-160]).transpose(1, 2).contiguous()
+            mel_seg = (
+                self.extract_features(audio_seg[..., :-160])
+                .transpose(1, 2)
+                .contiguous()
+            )
 
             base_binding.bind_input(
                 name="input_1",

--- a/src/tidytunes/models/dnsmos.py
+++ b/src/tidytunes/models/dnsmos.py
@@ -156,8 +156,8 @@ class DNSMOSPredictor(torch.nn.Module):
                 break
 
             shape = audio_seg.shape
-            audio_seg = audio_seg.reshape((-1, shape[-1]))
-            mel_seg = self.extract_features(audio_seg[..., :-160]).transpose(1, 2)
+            audio_seg = audio_seg.reshape((-1, shape[-1])).contiguous()
+            mel_seg = self.extract_features(audio_seg[..., :-160]).transpose(1, 2).contiguous()
 
             base_binding.bind_input(
                 name="input_1",


### PR DESCRIPTION
The data tensors were not contiguous, so the ONNX runtime received misaligned data. With this explicit call, the DNSMOS is now consistent.